### PR TITLE
Namespace generated go code, support include/exclude options

### DIFF
--- a/buf.gen.yaml
+++ b/buf.gen.yaml
@@ -1,6 +1,10 @@
 version: v2
+clean: true
 managed:
   enabled: true
+  override:
+  - file_option: go_package_prefix
+    value: github.com/bergundy/protoc-gen-nexus-temporal/gen
 plugins:
   - remote: buf.build/protocolbuffers/go
     out: gen
@@ -12,3 +16,6 @@ plugins:
     opt:
       - paths=source_relative
       - lang=go
+inputs:
+  - directory: proto
+  - directory: example/proto

--- a/buf.yaml
+++ b/buf.yaml
@@ -1,5 +1,7 @@
 version: v2
 modules:
+  - name: buf.build/bergundy/protoc-gen-nexus-temporal
+    path: proto
   - path: example/proto
 lint:
   use:

--- a/example/e2e_test.go
+++ b/example/e2e_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	example "github.com/bergundy/protoc-gen-nexus-temporal/gen/example/v1"
+	"github.com/bergundy/protoc-gen-nexus-temporal/gen/example/v1/examplev1nexustemporal"
 	"github.com/nexus-rpc/sdk-go/nexus"
 	"github.com/stretchr/testify/require"
 	nexuspb "go.temporal.io/api/nexus/v1"
@@ -16,8 +17,8 @@ import (
 	"go.temporal.io/sdk/workflow"
 )
 
-var oneWayClient = example.NewOneWayNexusClient("example-endpoint")
-var twoWayClient = example.NewTwoWayNexusClient("example-endpoint")
+var oneWayClient = examplev1nexustemporal.NewOneWayNexusClient("example-endpoint")
+var twoWayClient = examplev1nexustemporal.NewTwoWayNexusClient("example-endpoint")
 
 func CallerWorkflow(ctx workflow.Context) error {
 	output, err := oneWayClient.NoInput(ctx, workflow.NexusOperationOptions{})
@@ -33,7 +34,7 @@ func CallerWorkflow(ctx workflow.Context) error {
 }
 
 func CallerWorkflowAsync(ctx workflow.Context) error {
-	oneWayClient := example.NewOneWayNexusClient("example-endpoint")
+	oneWayClient := examplev1nexustemporal.NewOneWayNexusClient("example-endpoint")
 	outputFuture := oneWayClient.NoInputAsync(ctx, workflow.NexusOperationOptions{})
 	output, err := outputFuture.GetTyped(ctx)
 	if err != nil {
@@ -107,8 +108,8 @@ func TestE2E(t *testing.T) {
 	c, err := client.Dial(client.Options{HostPort: "localhost:7233"})
 	require.NoError(t, err)
 	w := worker.New(c, "example", worker.Options{})
-	example.RegisterTwoWayNexusServiceHandler(w, &twoWayHandler{})
-	example.RegisterOneWayNexusServiceHandler(w, &oneWayHandler{})
+	examplev1nexustemporal.RegisterTwoWayNexusServiceHandler(w, &twoWayHandler{})
+	examplev1nexustemporal.RegisterOneWayNexusServiceHandler(w, &oneWayHandler{})
 	w.RegisterWorkflow(CallerWorkflow)
 	w.RegisterWorkflow(CallerWorkflowAsync)
 	w.RegisterWorkflow(TwoWayWorkflow)

--- a/example/proto/example/v1/service.proto
+++ b/example/proto/example/v1/service.proto
@@ -3,7 +3,7 @@ syntax="proto3";
 package example.v1;
 
 import "google/protobuf/empty.proto";
-import "google/protobuf/timestamp.proto";
+import "nexustemporal/v1/options.proto";
 
 option go_package = "github.com/bergundy/protoc-gen-nexus-temporal/gen/example/v1;example";
 
@@ -16,13 +16,19 @@ message ExampleOutput {
 }
 
 service OneWay {
-  rpc NoInput(google.protobuf.Empty) returns (ExampleOutput) {
-  }
-  rpc NoOutput(ExampleInput) returns (google.protobuf.Empty) {
-  }
+  rpc NoInput(google.protobuf.Empty) returns (ExampleOutput);
+
+  rpc NoOutput(ExampleInput) returns (google.protobuf.Empty);
 }
 
 service TwoWay {
+  option (nexustemporal.v1.service).name = "example.v1.two-way";
+
   rpc Example(ExampleInput) returns (ExampleOutput) {
+    option (nexustemporal.v1.operation).name = "example";
+  }
+
+  rpc Ignored(google.protobuf.Empty) returns (google.protobuf.Empty) {
+    option (nexustemporal.v1.operation).disabled = true;
   }
 }

--- a/proto/nexustemporal/v1/options.proto
+++ b/proto/nexustemporal/v1/options.proto
@@ -1,0 +1,34 @@
+syntax = "proto3";
+
+package nexustemporal.v1;
+
+import "google/protobuf/descriptor.proto";
+
+option go_package = "github.com/bergundy/protoc-gen-nexus-temporal/gen/nexustemporal/v1";
+
+extend google.protobuf.ServiceOptions {
+  optional ServiceOptions service = 8233;
+}
+
+extend google.protobuf.MethodOptions {
+  optional OperationOptions operation = 8234;
+}
+
+message OperationOptions {
+  // boolean flag to disable nexus code generation for enabled service
+  bool disabled = 2;
+
+  // boolean flag to enable nexus code gneration for disabled service
+  bool enabled = 3;
+
+  // nexus operation name (defaults to proto method name)
+  string name = 1;
+}
+
+message ServiceOptions {
+  // boolean flag to disable nexus code generation for enabled service
+  bool disabled = 2;
+
+  // nexus service name (defaults to proto service full name)
+  string name = 1;
+}


### PR DESCRIPTION
### What
- modifies go code generated to use a nested `<package>nexustemporal` go package
- adds optional `include` and `exclude` plugin options that can be used to filter methods included in nexus code generation.

### Why
The intent of this PR is two-fold: 
1) avoid conflicts in generated types between this plugin and protoc-gen-go-temporal (FWIW, I plan to adopt this approach in the next major version of that plugin)
2) support controlled adoption of this plugin for existing services (e.g. exclude activity methods or "internal" methods).