### PR TITLE
Generate default ScheduleToCloseTimeout for nexus operations

### DIFF
--- a/buf.yaml
+++ b/buf.yaml
@@ -1,6 +1,8 @@
 version: v2
 modules:
   - path: example/proto
+deps:
+  - buf.build/bergundy/nexus
 lint:
   use:
     - BASIC

--- a/example/proto/example/v1/service.proto
+++ b/example/proto/example/v1/service.proto
@@ -4,6 +4,7 @@ package example.v1;
 
 import "google/protobuf/empty.proto";
 import "google/protobuf/go_features.proto";
+import "nexus/v1/options.proto";
 
 option features.(pb.go).api_level = API_HYBRID;
 option features.field_presence = IMPLICIT;
@@ -23,5 +24,9 @@ service OneWay {
 }
 
 service TwoWay {
-  rpc Example(ExampleInput) returns (ExampleOutput) {}
+  rpc Example(ExampleInput) returns (ExampleOutput) {
+    option (nexus.v1.operation) = {
+      schedule_to_close_timeout: {seconds: 3600}
+    };
+  }
 }

--- a/internal/plugin/plugin.go
+++ b/internal/plugin/plugin.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"slices"
+	"strconv"
 
 	nexusv1 "github.com/bergundy/nexus-proto-annotations/go/nexus/v1"
 	"github.com/dave/jennifer/jen"
@@ -269,6 +270,7 @@ func (p *Plugin) genClient(f *jen.File, svc *protogen.Service, nexusPkgPath stri
 			}).
 			Id(futureName).
 			BlockFunc(func(g *jen.Group) {
+				genScheduleToCloseDefault(g, method)
 				g.Id("fut").Op(":=").Id("c").Dot("client").Dot("ExecuteOperation").
 					CallFunc(func(g *jen.Group) {
 						g.Id("ctx")
@@ -312,6 +314,7 @@ func (p *Plugin) genClient(f *jen.File, svc *protogen.Service, nexusPkgPath stri
 					g.Var().Id("output").Qual(string(method.Output.GoIdent.GoImportPath), method.Output.GoIdent.GoName)
 				}
 
+				genScheduleToCloseDefault(g, method)
 				g.Id("fut").Op(":=").Id("c").Dot("client").Dot("ExecuteOperation").
 					CallFunc(func(g *jen.Group) {
 						g.Id("ctx")
@@ -370,6 +373,22 @@ func (p *Plugin) shouldIncludeOperation(m *protogen.Method) bool {
 
 func operationNameConst(svc *protogen.Service, method *protogen.Method) string {
 	return fmt.Sprintf("%s%sOperationName", svc.GoName, method.GoName)
+}
+
+// genScheduleToCloseDefault generates a conditional timeout default if the proto
+// operation defines a schedule_to_close_timeout.
+func genScheduleToCloseDefault(g *jen.Group, method *protogen.Method) {
+	timeout := operationOptions(method).GetScheduleToCloseTimeout()
+	if timeout == nil {
+		return
+	}
+	ns := timeout.AsDuration().Nanoseconds()
+	if ns <= 0 {
+		return
+	}
+	g.If(jen.Id("options").Dot("ScheduleToCloseTimeout").Op("==").Lit(0)).Block(
+		jen.Id("options").Dot("ScheduleToCloseTimeout").Op("=").Id(strconv.FormatInt(ns, 10)),
+	)
 }
 
 // operationOptions returns the OperationOptions for the given proto Method


### PR DESCRIPTION
## Summary

When a nexus operation defines `schedule_to_close_timeout` in its proto options, the generated client methods now inject a conditional default before calling `ExecuteOperation`. Callers still override it by setting `NexusOperationOptions.ScheduleToCloseTimeout` explicitly.

**Part 2 of 2** — depends on bergundy/nexus-proto-annotations#1 (merge that first).

### Generated output (before)

```go
func (c *Client) Example(ctx workflow.Context, input *v1.Input, options workflow.NexusOperationOptions) (*v1.Output, error) {
    var output v1.Output
    fut := c.client.ExecuteOperation(ctx, opName, input, options)
    err := fut.Get(ctx, &output)
    return &output, err
}
```

### Generated output (after, when proto defines `schedule_to_close_timeout: {seconds: 3600}`)

```go
func (c *Client) Example(ctx workflow.Context, input *v1.Input, options workflow.NexusOperationOptions) (*v1.Output, error) {
    var output v1.Output
    if options.ScheduleToCloseTimeout == 0 {
        options.ScheduleToCloseTimeout = 3600000000000
    }
    fut := c.client.ExecuteOperation(ctx, opName, input, options)
    err := fut.Get(ctx, &output)
    return &output, err
}
```

Operations without the proto option are unchanged.

## Changes

- `internal/plugin/plugin.go`: added `genScheduleToCloseDefault()` and wired it into both async and sync method generation
- `example/proto/example/v1/service.proto`: added example usage with timeout
- `buf.yaml`: added `buf.build/bergundy/nexus` dependency

## Testing

Tested locally by building the plugin against a local copy of the updated `nexus-proto-annotations`, generating code from the example proto, and verifying that:
- Operations with `schedule_to_close_timeout` get the conditional default in both async and sync methods
- Operations without it are unchanged