### PR TITLE
Use nexusannotations from nexus-rpc org

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -18,6 +18,9 @@ jobs:
           - windows-latest
     name: Build, Lint, Test (${{ matrix.runs-on }})
     runs-on: ${{ matrix.runs-on }}
+    permissions:
+      contents: read
+      pull-requests: write
     defaults:
       run:
         shell: bash
@@ -50,6 +53,8 @@ jobs:
           breaking: false
           # Don't format on windows due to newline differences.
           format: ${{ matrix.runs-on == 'ubuntu-latest' }}
+          # Fork PRs get a read-only token, so posting a PR comment fails. Only comment for same-repo PRs.
+          pr_comment: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
 
       - name: Install the protoc-gen-go-nexus dependency
         run: go install github.com/bergundy/protoc-gen-go-nexus/cmd/protoc-gen-go-nexus@latest

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -58,7 +58,7 @@ jobs:
         run: PATH=${PWD}:${PATH} buf generate
 
       - name: Lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@v9
         with:
           args: --verbose --timeout 3m --fix=false
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Follow instruction in the repo's [README](https://github.com/bergundy/protoc-gen
 
 ### Customize code generation
 
-Follow the instructions in [nexus-proto-annotations](https://github.com/bergundy/nexus-proto-annotations) for modifying
+Follow the instructions in [nexus-proto-annotations](https://github.com/nexus-rpc/nexus-proto-annotations) for modifying
 the service and operation names and tagging for includes and excludes.
 
 ### Create a proto file

--- a/go.mod
+++ b/go.mod
@@ -1,10 +1,10 @@
 module github.com/bergundy/protoc-gen-go-nexus-temporal
 
-go 1.23.4
+go 1.25.4
 
 require (
-	github.com/bergundy/nexus-proto-annotations v0.1.0
 	github.com/dave/jennifer v1.7.1
+	github.com/nexus-rpc/nexus-proto-annotations v0.1.0
 	github.com/nexus-rpc/sdk-go v0.4.0
 	github.com/nexus-rpc/sdk-go/contrib/nexusproto v0.1.0
 	github.com/spf13/pflag v1.0.5

--- a/go.sum
+++ b/go.sum
@@ -1,8 +1,6 @@
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/benbjohnson/clock v1.1.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
-github.com/bergundy/nexus-proto-annotations v0.1.0 h1:A4dwYmbD/a9fx267DgtJq8j5Tcuw49Z7JfZcGKFeSdQ=
-github.com/bergundy/nexus-proto-annotations v0.1.0/go.mod h1:fw4ftU2X2TA6g3vO6pblwotc9OYJhNQJEPyatps6DdA=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
@@ -50,6 +48,8 @@ github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
 github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
+github.com/nexus-rpc/nexus-proto-annotations v0.1.0 h1:2fELd+9sqUtNu6Fg//pw8YFsxOvp8vZ8hfP0nHhNI80=
+github.com/nexus-rpc/nexus-proto-annotations v0.1.0/go.mod h1:n3UjF1bPCW8llR8tHvbxJ+27yPWrhpo8w/Yg1IOuY0Y=
 github.com/nexus-rpc/sdk-go v0.4.0 h1:A/IjWWAiWecnYnt7uI0Cw6ci6zJwaM9Ma3q4hDDxUVc=
 github.com/nexus-rpc/sdk-go v0.4.0/go.mod h1:TpfkM2Cw0Rlk9drGkoiSMpFqflKTiQLWUNyKJjF8mKQ=
 github.com/nexus-rpc/sdk-go/contrib/nexusproto v0.1.0 h1:UrxpCX+m2Vl5ah+iDvzTzP5RxVdRQMiQEDfhbMuKI0o=

--- a/internal/plugin/plugin.go
+++ b/internal/plugin/plugin.go
@@ -7,8 +7,8 @@ import (
 	"runtime"
 	"slices"
 
-	nexusv1 "github.com/bergundy/nexus-proto-annotations/go/nexus/v1"
 	"github.com/dave/jennifer/jen"
+	nexusv1 "github.com/nexus-rpc/nexus-proto-annotations/go/nexusannotations/v1"
 	"github.com/spf13/pflag"
 	"google.golang.org/protobuf/compiler/protogen"
 	"google.golang.org/protobuf/proto"
@@ -143,7 +143,7 @@ func (p *Plugin) Run(plugin *protogen.Plugin) error {
 		}
 
 		if err := f.Render(
-			p.Plugin.NewGeneratedFile(
+			p.NewGeneratedFile(
 				file.GeneratedFilenamePrefix+generatedFilenameExtension,
 				protogen.GoImportPath(importPath),
 			),
@@ -160,7 +160,7 @@ func (p *Plugin) genCodeGenerationHeader(f *jen.File, target *protogen.File) {
 	f.PackageComment("versions: ")
 	f.PackageComment(fmt.Sprintf("    protoc-gen-go-nexus-temporal %s (%s)", p.version, p.commit))
 	f.PackageComment(fmt.Sprintf("    go %s", runtime.Version()))
-	compilerVersion := p.Plugin.Request.CompilerVersion
+	compilerVersion := p.Request.CompilerVersion
 	if compilerVersion != nil {
 		f.PackageComment(fmt.Sprintf("    protoc %s", compilerVersion.String()))
 	} else {


### PR DESCRIPTION
Fix lint as part of upgrading golangci-lint and Go version to 1.25.4